### PR TITLE
Minor doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It has since undergone a number of fundamental API changes.
 * Before using this crate, you should install Gurobi and obtain a [license](http://www.gurobi.com/downloads/licenses/license-center).
 
 * **Linking**: Make sure that the environment variable `GUROBI_HOME` is set to the installation path of Gurobi
-  (like `C:\gurobi652\win64` or `/opt/gurobi652/linux64`).  If you are using the Conda package
+  (like `C:\gurobi911\win64` or `/opt/gurobi911/linux64`).  If you are using the Conda package
   from the Gurobi channel, the build script will fall back to `GUROBI_HOME=${CONDA_PREFIX}`, so you
   should not set `GUROBI_HOME`.
 

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -356,16 +356,15 @@ impl<'a> MIPSolCtx<'a> {
 /// Callback context object during [`MIPNODE`](https://www.gurobi.com/documentation/9.1/refman/cb_codes.html).
 pub struct MIPNodeCtx<'a>(CbCtx<'a>);
 impl<'a> MIPNodeCtx<'a> {
-    /// Optimization status of current MIP node. This will query the solution for ALL
-    /// variables, and return the subset provided, so you should avoid calling this method
-    /// multiple times per callback.
+    /// Optimization status of current MIP node.
     pub fn status(&self) -> Result<Status> {
         self.0
             .get_int(MIPNODE, MIPNODE_STATUS)
             .map(|s| s.try_into().unwrap())
     }
 
-    /// Get the optimal solution to this MIP node relaxation.
+    /// Get the optimal solution to this MIP node relaxation.  This will query the solution for ALL variables, and
+    /// return the subset provided, so you should avoid calling this method multiple times per callback.
     pub fn get_solution<I, V>(&self, vars: I) -> Result<Vec<f64>>
     where
         V: Borrow<Var>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! * Before using this crate, you should install Gurobi and obtain a [license](http://www.gurobi.com/downloads/licenses/license-center).
 //!
 //! * Make sure that the environment variable `GUROBI_HOME` is set to the installation path of Gurobi
-//!   (like `C:\gurobi652\win64` or `/opt/gurobi652/linux64`).  If you are using the Conda package
+//!   (like `C:\gurobi911\win64` or `/opt/gurobi911/linux64`).  If you are using the Conda package
 //!   from the Gurobi channel, the build script will fall back to `GUROBI_HOME=${CONDA_PREFIX}`, so you
 //!   should not set `GUROBI_HOME`.
 //!


### PR DESCRIPTION
This PR resolves two minor issues in the docs:
1. the path example refers to Gurobi version 6.5.2, but the package requires at least version 9.0.0
2. the user is warned that `MIPNodeCtx::status()` is an expensive method, which it is not