### PR TITLE
fix: reset variables' Obj attr on new objective.

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -860,7 +860,12 @@ impl Model {
 
         let (coeff_map, obj_cons) = expr.into_parts();
 
-        self.set_obj_attr_batch(attr::Obj, coeff_map)?;
+        self.set_obj_attr_batch(
+            attr::Obj,
+            self.get_vars()?
+                .iter()
+                .map(|v| (*v, coeff_map.get(v).copied().unwrap_or(0.))),
+        )?;
         self.set_attr(attr::ObjCon, obj_cons)?;
         self.set_attr(attr::ModelSense, sense)
     }

--- a/tests/resolve_with_new_objective.rs
+++ b/tests/resolve_with_new_objective.rs
@@ -1,0 +1,37 @@
+use grb::prelude::*;
+
+#[test]
+fn optimize() -> grb::Result<()> {
+    let mut model = Model::new("model")?;
+
+    let x = add_ctsvar!(model, name: "x", bounds: 0..)?;
+    let y = add_ctsvar!(model, name: "y", bounds: 0..)?;
+
+    model.add_constr("c", c!(x + y <= 10))?;
+
+    model.set_objective(2 * x + 1, ModelSense::Maximize)?;
+    model.optimize()?;
+    let obj1 = model.get_attr(attr::ObjVal)?;
+
+    let x1 = model.get_obj_attr(attr::X, &x)?;
+    let y1 = model.get_obj_attr(attr::X, &y)?;
+    println!("x:{x1}    y:{y1}");
+
+    model.set_objective(y, ModelSense::Maximize)?;
+    model.optimize()?;
+
+    let obj2 = model.get_attr(attr::ObjVal)?;
+    let x2 = model.get_obj_attr(attr::X, &x)?;
+    let y2 = model.get_obj_attr(attr::X, &y)?;
+    println!("x:{x2}    y:{y2}");
+
+    assert_eq!(obj1, 21.);
+    assert_eq!(x1, 10.);
+    assert_eq!(y1, 0.);
+
+    assert_eq!(obj2, 10.);
+    assert_eq!(x2, 0.);
+    assert_eq!(y2, 10.);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes !11.

Set all variables' Obj value when setting the objective via .set_objective, even for variables not in the expression (use 0.0).